### PR TITLE
fix overwriting the reciprocated transaction during block acceptance

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -554,7 +554,7 @@ pub async fn propose_block(
             coinbase_user.balance += BLOCK_REWARD;
         }
 
-        let holding: HashMap<String, Transaction> = HashMap::new();
+        let mut holding: HashMap<String, Transaction> = HashMap::new();
 
         // Play out the transactions
         for fingerprint in &new_block.transaction_list {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -573,7 +573,7 @@ pub async fn propose_block(
                 // if the receiver is a bot, they will reciprocate
                 if users_store.get(target).unwrap().is_bot {
                     let transaction_id = calculate_transaction_id(target, source);
-                    pending_transactions.insert(
+                    holding.insert(
                         transaction_id,
                         Transaction {
                             source: target.clone(),


### PR DESCRIPTION
The transaction is lost during the case where the block consists of two transactions, `user->bot1` and `bot1->user`. The block acceptance code overwrites the second transaction with the newly created reciprocate transaction.

This PR fixes the problem.